### PR TITLE
Stop same assignment

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,6 +21,35 @@ brothers = [
      },
 ]
 
-for brother in brothers:
-    brother['current_territory'] = random.choice(territories)
-    print(f'Brother {brother["name"]} has been assigened territory #{brother["current_territory"]}')
+# assignment function
+def assigner(brothers, territories):
+    # Copy the list to maintain the original list 
+    available_territories = territories.copy()
+
+    for brother in brothers:
+        # filters out the brother's previous territory if possible
+        filtered_territories = [t for t in territories if t != brother['previous_territory']]
+
+        # if no Terr are left that aren't the brothers previous, use the available ones
+        if not filtered_territories:
+            filtered_territories = available_territories
+
+        # Randomly select a new Terr from the filtered list
+        new_territory = random.choice(filtered_territories)
+
+        # Update/Assign brother's territory information
+        brother['previous_territory'] = brother['current_territory']
+        brother['current_territory'] = new_territory
+
+        # Remove the newly assign territory from the pool of available territories
+        available_territories.remove(new_territory)
+        
+        print(f'Brother {brother["name"]} has been assigened territory #{brother["current_territory"]}')
+
+        # Reset the available territories if all have been assigned
+        if not available_territories:
+            available_territories = territories.copy()
+
+assigner(brothers, territories)
+
+# print(brothers)


### PR DESCRIPTION
fixed prior logic, wrapped previous loop in a function and removed the newly added territory from a copied list (to not affect original list) as to not reassign the same territory twice.